### PR TITLE
parallel: per-page recipe (with timeout and dummy fallback)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ rm-parallel: stop-server
 $(WS_PAR)/mets.xml: $(WS)
 	cp -r $(WS) $(WS_PAR)
 
-parallel-chunks: page_ranges != ocrd workspace -d $(WS_PAR) list-page -D $(NUMBER_OF_THREADS) -f comma-separated
+parallel-chunks: page_ranges = $(shell ocrd workspace -d $(WS_PAR) list-page -D $(NUMBER_OF_THREADS) -f comma-separated)
 parallel-chunks: CLIPARAMS := -U $(SOCK) $(CLIPARAMS)
 parallel-chunks: $(WS_PAR)/mets.xml
 	cd $(WS_PAR) ; \

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,13 @@ WS_SEQ = ws-sequential
 WS_PAR = ws-parallel
 SOCK = $(PWD)/server.sock
 NUMBER_OF_THREADS = 5
+PAGE_TIMEOUT = 120
 ECHO = 
 PROCESSOR = $(ECHO) ocrd-vandalize
+CLIPARAMS = -I DEFAULT -O VANDALIZED
 
 # Clone the workspace and download only the `DEFAULT` fileGrp
-clone:
+$(WS) clone:
 	ocrd -l DEBUG workspace -d $(WS) clone \
 		'https://content.staatsbibliothek-berlin.de/dc/PPN891267093.mets.xml' \
 		-q DEFAULT \
@@ -18,12 +20,12 @@ clone:
 #
 # Sequential workflow w/o METS server
 #
-$(WS_SEQ)/mets.xml:
+$(WS_SEQ)/mets.xml: $(WS)
 	cp -r $(WS) $(WS_SEQ)
 
 sequential: $(WS_SEQ)/mets.xml
 	cd $(WS_SEQ) ; \
-	$(PROCESSOR) -I DEFAULT -O VANDALIZED
+	$(PROCESSOR) $(CLIPARAMS)
 
 rm-sequential:
 	rm -rf $(WS_SEQ)
@@ -36,16 +38,25 @@ rm-sequential:
 start-server: $(WS_PAR)/mets.xml
 	ocrd workspace -d $(WS_PAR)  -U $(SOCK) server start
 
-rm-parallel:
+stop-server: $(WS_PAR)/mets.xml
+	-ocrd workspace -d $(WS_PAR)  -U $(SOCK) server stop
+
+rm-parallel: stop-server
 	rm -rf $(WS_PAR)
 
-$(WS_PAR)/mets.xml:
+$(WS_PAR)/mets.xml: $(WS)
 	cp -r $(WS) $(WS_PAR)
 
+parallel-chunks: page_ranges != ocrd workspace -d $(WS_PAR) list-page -D $(NUMBER_OF_THREADS) -f comma-separated
+parallel-chunks: CLIPARAMS := -U $(SOCK) $(CLIPARAMS)
+parallel-chunks: $(WS_PAR)/mets.xml
+	cd $(WS_PAR) ; \
+	for chunk in $(page_ranges); do $(PROCESSOR) $(CLIPARAMS) -g $$chunk & done; \
+	wait
+
+parallel: CLIPARAMS := -U $(SOCK) $(CLIPARAMS)
 parallel: $(WS_PAR)/mets.xml
 	cd $(WS_PAR) ; \
-	page_ranges=( $$(ocrd workspace list-page -D $(NUMBER_OF_THREADS) -f comma-separated) ) ;\
-	for chunk in $$(seq 0 $$(( $(NUMBER_OF_THREADS) -1 )));do \
-		$(PROCESSOR) -U $(SOCK) -I DEFAULT -O VANDALIZED -g $${page_ranges[$$chunk]} &\
-	done; wait
+	ocrd workspace list-page | \
+	parallel -j $(NUMBER_OF_THREADS) "timeout $(PAGE_TIMEOUT) $(PROCESSOR) $(CLIPARAMS) -g {} || $(ECHO) ocrd-dummy $(CLIPARAMS) -g {}"
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PROCESSOR = $(ECHO) ocrd-vandalize
 CLIPARAMS = -I DEFAULT -O VANDALIZED
 
 # Clone the workspace and download only the `DEFAULT` fileGrp
-$(WS) clone:
+$(WS)/mets.xml clone:
 	ocrd -l DEBUG workspace -d $(WS) clone \
 		'https://content.staatsbibliothek-berlin.de/dc/PPN891267093.mets.xml' \
 		-q DEFAULT \
@@ -20,7 +20,7 @@ $(WS) clone:
 #
 # Sequential workflow w/o METS server
 #
-$(WS_SEQ)/mets.xml: $(WS)
+$(WS_SEQ)/mets.xml: $(WS)/mets.xml
 	cp -r $(WS) $(WS_SEQ)
 
 sequential: $(WS_SEQ)/mets.xml
@@ -44,7 +44,7 @@ stop-server: $(WS_PAR)/mets.xml
 rm-parallel: stop-server
 	rm -rf $(WS_PAR)
 
-$(WS_PAR)/mets.xml: $(WS)
+$(WS_PAR)/mets.xml: $(WS)/mets.xml
 	cp -r $(WS) $(WS_PAR)
 
 parallel-chunks: page_ranges = $(shell ocrd workspace -d $(WS_PAR) list-page -D $(NUMBER_OF_THREADS) -f comma-separated)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ cf. `Makefile` for the code
 
 `make sequential` to run workflow in sequence
 
-`make start-server` to start the METS server
-`make parallel` to run workflow in parallel
+`make start-server &` to start the METS server (in the background)
+
+`make parallel` to run workflow in parallel page-wise (with timeouts and error fallback)
+
+`make parallel-chunks` to run workflow in parallel job-wise (without error handling)
 
 `ocrd workspace list-page --help` for the partitioning/chunking options
 
@@ -32,27 +35,27 @@ Sequential:
 /usr/bin/time make sequential  169.32s user 6.59s system 100% cpu 2:55.65 total
 ```
 
-Parallel w/4 jobs:
+Parallel chunks w/4 jobs:
 
 ```
 164.22user 6.89system 0:47.53elapsed 359%CPU (0avgtext+0avgdata 192548maxresident)k
 0inputs+1274824outputs (0major+3642408minor)pagefaults 0swaps
-/usr/bin/time make parallel NUMBER_OF_THREADS=4  164.22s user 6.90s system 359% cpu 47.536 total
+/usr/bin/time make parallel-chunks NUMBER_OF_THREADS=4  164.22s user 6.90s system 359% cpu 47.536 total
 ```
 
-Parallel w/8 jobs
+Parallel chunks w/8 jobs
 
 ```
 226.84user 9.27system 0:34.18elapsed 690%CPU (0avgtext+0avgdata 191928maxresident)k
 0inputs+1274856outputs (0major+3827022minor)pagefaults 0swaps
-/usr/bin/time make parallel NUMBER_OF_THREADS=8  226.85s user 9.28s system 690% cpu 34.188 total  
+/usr/bin/time make parallel-chunks NUMBER_OF_THREADS=8  226.85s user 9.28s system 690% cpu 34.188 total
 ```
 
-Parallel w/16 jobs (sanity check)
+Parallel chunks w/16 jobs (sanity check)
 
 ```
 252.12user 11.21system 0:35.84elapsed 734%CPU (0avgtext+0avgdata 191968maxresident)k
 400inputs+1274920outputs (19major+4210729minor)pagefaults 0swaps
-/usr/bin/time make parallel NUMBER_OF_THREADS=16  252.13s user 11.21s system 734% cpu 35.850 total 
+/usr/bin/time make parallel-chunks NUMBER_OF_THREADS=16  252.13s user 11.21s system 734% cpu 35.850 total
 ```
 


### PR DESCRIPTION
fixes #1 – of course, with per-page parallelism, it becomes slower (more overhead), but per-page fallback may be worth it.

Or should I rather write a separate rule illustrating this?